### PR TITLE
write-file-trim 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# write-file-trim [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Travis](https://img.shields.io/travis/IonicaBizau/write-file-trim.svg)](https://travis-ci.org/IonicaBizau/write-file-trim/) [![Version](https://img.shields.io/npm/v/write-file-trim.svg)](https://www.npmjs.com/package/write-file-trim) [![Downloads](https://img.shields.io/npm/dt/write-file-trim.svg)](https://www.npmjs.com/package/write-file-trim) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# write-file-trim
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Travis](https://img.shields.io/travis/IonicaBizau/write-file-trim.svg)](https://travis-ci.org/IonicaBizau/write-file-trim/) [![Version](https://img.shields.io/npm/v/write-file-trim.svg)](https://www.npmjs.com/package/write-file-trim) [![Downloads](https://img.shields.io/npm/dt/write-file-trim.svg)](https://www.npmjs.com/package/write-file-trim) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Write the content in a file after removing the trailing spaces.
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "spaces"
   ],
   "license": "MIT",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "lib/index.js",
   "scripts": {
     "test": "node test"
@@ -43,6 +43,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
